### PR TITLE
JWT token verification now can return user object

### DIFF
--- a/client/src/store/actions/auth.actions.js
+++ b/client/src/store/actions/auth.actions.js
@@ -71,18 +71,20 @@ export const tryLocalSignIn = () => (dispatch, getState, { mernApi }) => {
       });
     }
     mernApi.setAuthToken(authInfo.token);
-    return mernApi.post('/api/auth/verify-token', { refreshToken: true }).then(
-      (response) => {
-        authInfo.token = response.data.token;
-        authInfo.expiresAt = response.data.expiresAt;
-        dispatch(
-          signInSuccess(authInfo, actionTypes.TRY_LOCAL_SIGN_IN_SUCCESS)
-        );
-      },
-      (err) => {
-        dispatch(tryLocalSignInFail());
-      }
-    );
+    return mernApi
+      .post('/api/auth/verify-jwt-token', { refreshToken: true })
+      .then(
+        (response) => {
+          authInfo.token = response.data.token;
+          authInfo.expiresAt = response.data.expiresAt;
+          dispatch(
+            signInSuccess(authInfo, actionTypes.TRY_LOCAL_SIGN_IN_SUCCESS)
+          );
+        },
+        (err) => {
+          dispatch(tryLocalSignInFail());
+        }
+      );
   } catch (err) {
     dispatch(tryLocalSignInFail(err));
   }

--- a/client/src/store/actions/auth.actions.js
+++ b/client/src/store/actions/auth.actions.js
@@ -72,11 +72,15 @@ export const tryLocalSignIn = () => (dispatch, getState, { mernApi }) => {
     }
     mernApi.setAuthToken(authInfo.token);
     return mernApi
-      .post('/api/auth/verify-jwt-token', { refreshToken: true })
+      .post('/api/auth/verify-jwt-token', {
+        refreshToken: true,
+        refreshUser: true,
+      })
       .then(
         (response) => {
           authInfo.token = response.data.token;
           authInfo.expiresAt = response.data.expiresAt;
+          authInfo.user = response.data.user;
           dispatch(
             signInSuccess(authInfo, actionTypes.TRY_LOCAL_SIGN_IN_SUCCESS)
           );

--- a/mobile/src/store/actions/auth.actions.js
+++ b/mobile/src/store/actions/auth.actions.js
@@ -114,11 +114,15 @@ export const tryLocalSignIn = () => (dispatch, getState, { mernApi }) => {
       }
       mernApi.setAuthToken(authInfo.token);
       return mernApi
-        .post('/api/auth/verify-jwt-token', { refreshToken: true })
+        .post('/api/auth/verify-jwt-token', {
+          refreshToken: true,
+          refreshUser: true,
+        })
         .then(
           (response) => {
             authInfo.token = response.data.token;
             authInfo.expiresAt = response.data.expiresAt;
+            authInfo.user = response.data.user;
             dispatch(
               signInSuccess(authInfo, actionTypes.TRY_LOCAL_SIGN_IN_SUCCESS)
             );

--- a/mobile/src/store/actions/auth.actions.js
+++ b/mobile/src/store/actions/auth.actions.js
@@ -114,7 +114,7 @@ export const tryLocalSignIn = () => (dispatch, getState, { mernApi }) => {
       }
       mernApi.setAuthToken(authInfo.token);
       return mernApi
-        .post('/api/auth/verify-token', { refreshToken: true })
+        .post('/api/auth/verify-jwt-token', { refreshToken: true })
         .then(
           (response) => {
             authInfo.token = response.data.token;

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -132,11 +132,13 @@ const verifyTokenSchema = Joi.object({
 });
 
 /**
- * @function verifyToken
+ * @function verifyJwtToken
  * Verify JWT token
  *
+ * @param {boolean} req.body.refreshToken If true, a new JWT token will be included in the response
+ * @param {boolean} req.body.refreshUser If true, an user object will be included in the response
  */
-module.exports.verifyToken = (req, res, next) => {
+module.exports.verifyJwtToken = (req, res, next) => {
   verifyTokenSchema
     .validateAsync(req.body)
     .then((payload) => {

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -127,7 +127,8 @@ module.exports.sendToken = (req, res, next) => {
  * JOI schema for validating verifyToken payload
  */
 const verifyTokenSchema = Joi.object({
-  refreshToken: Joi.boolean(),
+  refreshToken: Joi.boolean().default(false),
+  refreshUser: Joi.boolean().default(false),
 });
 
 /**
@@ -141,13 +142,22 @@ module.exports.verifyToken = (req, res, next) => {
     .then((payload) => {
       req.body = payload;
       if (req.user) {
-        let result = { status: 'pass' };
+        let result = { message: 'JWT token is valid' };
+
         if (req.body.refreshToken) {
           result = {
             ...result,
             ...req.user.generateJwtToken(req.user.signedInWithProvider),
           };
         }
+
+        if (req.body.refreshUser) {
+          result = {
+            ...result,
+            user: req.user.toJsonFor(req.user),
+          };
+        }
+
         res.status(200).json(result);
       }
     })

--- a/server/routes/api/auth.route.js
+++ b/server/routes/api/auth.route.js
@@ -22,7 +22,7 @@ router.post(
   authCtrl.googleSignIn
 );
 
-router.post('/verify-token', jwtAuthenticate, authCtrl.verifyToken);
+router.post('/verify-jwt-token', jwtAuthenticate, authCtrl.verifyJwtToken);
 
 router.post('/reset-password/:token', authCtrl.resetPassword);
 


### PR DESCRIPTION
- Refactor `/api/auth/verify-token` => `/api/auth/verify-jwt-token`
- Making request to `/api/auth/verify-jwt-toke` with `{ refreshUser: true }` payload will include the user object in the response 