### PR TITLE
fix: update production Dockerfiles to use yarn instead of npm

### DIFF
--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -1,17 +1,17 @@
-FROM node:lts-buster as builder
+FROM node:lts-buster AS builder
 WORKDIR /mern-stack/client
 COPY ./client ./
-RUN npm ci
+RUN yarn install --frozen-lockfile
 ARG facebook_app_id
 ENV REACT_APP_FACEBOOK_APP_ID=${facebook_app_id}
 ARG google_client_id
 ENV REACT_APP_GOOGLE_CLIENT_ID=${google_client_id}
 ARG version
 ENV REACT_APP_VERSION=${version}
-RUN npm run build
+RUN yarn build
 
 FROM nginx:stable-alpine
 COPY --from=builder /mern-stack/client/build /usr/share/nginx/html
 COPY ./client/nginx.service.conf.prod /etc/nginx/conf.d/default.conf
 EXPOSE 3000
-CMD ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && nginx -g "daemon off;"
+CMD ["sh", "-c", "ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && nginx -g 'daemon off;'"]

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -2,5 +2,5 @@ FROM node:lts-buster
 WORKDIR /mern-stack/server
 COPY ./server ./
 # NOTE: We don't copy the .env file. Please specify env vars at runtime
-RUN npm ci
-CMD ["npm", "run", "prod"]
+RUN yarn install --frozen-lockfile
+CMD ["yarn", "prod"]


### PR DESCRIPTION
 ## Summary
  - Update production Dockerfiles to use yarn instead of npm for consistency
  - Fix Docker build failures in CI/CD pipeline caused by npm/yarn mismatch